### PR TITLE
Finish implementing updateCityDetail.js

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 city_detail/
 external_pages/
 map/
+scripts/city_detail.html.handlebars

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
         "eslint": "^8.37.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-prettier": "^8.8.0",
+        "handlebars": "^4.7.7",
         "jest": "^29.5.0",
         "luxon": "^3.3.0",
-        "mustache": "^4.2.0",
         "node-fetch": "^2.6.11",
         "papaparse": "^5.4.1",
         "prettier": "^2.8.7"
@@ -3922,6 +3922,27 @@
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
     },
+    "node_modules/handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -5257,7 +5278,6 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5268,19 +5288,16 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "node_modules/mustache": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
-      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
-      "dev": true,
-      "bin": {
-        "mustache": "bin/mustache"
-      }
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
     "node_modules/node-fetch": {
@@ -6358,6 +6375,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/uglify-js": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -6556,6 +6586,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "eslint": "^8.37.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-prettier": "^8.8.0",
+    "handlebars": "^4.7.7",
     "jest": "^29.5.0",
     "luxon": "^3.3.0",
-    "mustache": "^4.2.0",
     "node-fetch": "^2.6.11",
     "papaparse": "^5.4.1",
     "prettier": "^2.8.7"

--- a/scripts/city_detail.html.handlebars
+++ b/scripts/city_detail.html.handlebars
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <!-- Bootstrap CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-F3w7mX95PdgyTmZZMECAngseQB83DfGTowi0iMjiWaeVhAn4FJkqJByhZMI3AhiU" crossorigin="anonymous">
+
+    <style>
+        body {
+            background-color: #20c9c9;
+            background-image: url("bg-photo.jpg");
+            background-position: center center;
+            background-repeat: no-repeat;
+            background-attachment: fixed;
+            background-size: cover;
+        }
+        main {
+            word-break: break-word;
+            width: calc(100% - 2rem);
+            background-color: white;
+        }
+        .site-header {
+            background-color: #4d4d4d;
+            color: white;
+        }
+        .all-caps-link {
+            display: inline-block;
+            text-transform: uppercase;
+            text-decoration-line: none;
+            color: unset;
+        }
+        .all-caps-link:hover {
+            color: unset;
+        }
+        .attachment + .attachment {
+            margin-top: 3rem;
+        }
+        .button {
+              background-color: #21ccb9;
+              border: none;
+              color: white;
+              padding: 7px 16px;
+              text-align: center;
+              text-decoration: none;
+              display: inline-block;
+              font-size: 16px;
+            }
+    </style>
+
+    <title>Parking Reform Network - Reforms in {{city}}, {{state}}</title>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-5MFS4ZVMY3"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-5MFS4ZVMY3');
+</script>
+
+</head>
+<body>
+    <header class="site-header container-fluid">
+        <h1 class="p-2">
+            <a class="p-1 all-caps-link" href="https://parkingreform.org">
+                Parking Reform Network
+            </a>
+        </h1>
+    </header>
+    <main class="
+        container-md
+        p-3 p-sm-4
+        mt-3 mt-sm-4 mt-md-5
+        col-11 col-md-9
+    ">
+      <div class="container-fluid">
+      <div class="row" >
+        <div class="col-sm-8">
+        <header>
+            <h1 class="display-3">{{city}}, {{state}}</h1>
+        </header>
+        </div>
+        <div class="col-sm-4" align="center">
+            <span class="display-8">Support this project with a donation</span>
+            <!-- Begin Give Lively Fundraising Widget -->
+<script>gl=document.createElement('script');gl.src='https://secure.givelively.org/widgets/simple_donation/parking-reform-network.js?show_suggested_amount_buttons=false&show_in_honor_of=false&address_required=false&has_required_custom_question=null&prefilled_donation_amount=25';document.getElementsByTagName('head')[0].appendChild(gl);</script><div id="give-lively-widget" class="gl-simple-donation-widget"></div>
+<!-- End Give Lively Fundraising Widget -->
+        </div>
+    </div>
+    </div>
+        <hr />
+        <h2>Summary</h2>
+        <p class="lead">{{summary}}</p>
+        <hr />
+        <dl class="row">
+            <dt class="col-12 col-sm-4 col-lg-3">Implementation Status</dt>
+            <dd class="col-12 col-sm-8 col-lg-9">{{status}}</dd>
+
+            <dt class="col-12 col-sm-4 col-lg-3">Reform Type</dt>
+            <dd class="col-12 col-sm-8 col-lg-9">{{reformType}}</dd>
+
+            <dt class="col-12 col-sm-4 col-lg-3">Land Uses</dt>
+            <dd class="col-12 col-sm-8 col-lg-9">{{uses}}</dd>
+
+            <dt class="col-12 col-sm-4 col-lg-3">Scope of Reform</dt>
+            <dd class="col-12 col-sm-8 col-lg-9">{{magnitude}}</dd>
+            <dt class="col-12 col-sm-4 col-lg-3">Requirements</dt>
+            <dd class="col-12 col-sm-8 col-lg-9">{{requirements}}</dd>
+            <dt class="col-12 col-sm-4 col-lg-3">Reporter</dt>
+            <dd class="col-12 col-sm-8 col-lg-9">{{reporter}}</dd>
+
+
+        {{#each citations}}
+            <section class="my-3">
+                <header>
+                    <h2>Citation {{idx}}</h2>
+                </header>
+                <dl class="row">
+                    <dt class="col-12 col-sm-4 col-lg-3">Source Description</dt>
+                    <dd class="col-12 col-sm-8 col-lg-9">{{sourceDescription}}</dd>
+
+                    <dt class="col-12 col-sm-4 col-lg-3">Type</dt>
+                    <dd class="col-12 col-sm-8 col-lg-9">{{type}}</dd>
+
+                    <dt class="col-12 col-sm-4 col-lg-3">URL</dt>
+                    <dd class="col-12 col-sm-8 col-lg-9"><a target="_blank" href="{{url}}">{{url}}</a></dd>
+
+                    <dt class="col-12 col-sm-4 col-lg-3">Notes</dt>
+                    <dd class="col-12 col-sm-8 col-lg-9">{{notes}}</dd>
+                </dl>
+                {{#if attachments}}
+                    <h3>Attachments and Screenshots</h3>
+                    <ul class="mt-4 list-unstyled">
+                    {{#each attachments}}
+                        <li class="attachment">
+                            {{#if isDoc}}
+                            <a target="_blank" href="{{outputPath}}">{{fileName}}</a>
+                            {{else}}
+                            <img class="img-fluid" border="1" src="{{outputPath}}">
+                            {{/if}}
+                    {{/each}}
+                    </ul>
+                {{/if}}
+            </section>
+        {{/each}}
+        </div>
+    </div>
+
+    <!-- Bootstrap Bundle with Popper -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-/bQdsTh/da6pkI1MST/rWKFNjaCP5gBSY4sEBT38Q/9RBh9AH40zEOg7Hlq2THRZ" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/scripts/city_detail_last_updated.txt
+++ b/scripts/city_detail_last_updated.txt
@@ -1,1 +1,1 @@
-May 10, 2023, 2:14:14 PM America/Mexico_City
+May 8, 2023, 6:21:19 PM America/Mexico_City

--- a/scripts/tests/updateCityDetail.test.js
+++ b/scripts/tests/updateCityDetail.test.js
@@ -1,5 +1,9 @@
 const { describe, expect, test } = require("@jest/globals");
-const { needsUpdate, parseDatetime } = require("../updateCityDetail");
+const {
+  needsUpdate,
+  normalizeAttachments,
+  parseDatetime,
+} = require("../updateCityDetail");
 
 describe("needsUpdate()", () => {
   test("returns false if everything is older than globalLastUpdated", () => {
@@ -100,4 +104,42 @@ describe("needsUpdate()", () => {
     globalLastUpdated = parseDatetime("May 6, 2023, 11:00:00 AM PDT");
     expect(needsUpdate(entries, globalLastUpdated)).toBe(true);
   });
+});
+
+test("normalizeAttachments() converts string entries into objects", () => {
+  const input = [
+    { Attachments: "" },
+    { Attachments: "https://prn.org/photo1.png" },
+    { Attachments: "https://prn.org/doc1.pdf https://prn.org/img2.jpg" },
+  ];
+  normalizeAttachments(input, "MyCity_AZ");
+  expect(input).toEqual([
+    { Attachments: [] },
+    {
+      Attachments: [
+        {
+          url: "https://prn.org/photo1.png",
+          fileName: "photo1.png",
+          isDoc: false,
+          outputPath: "attachment_images/MyCity_AZ_2_1.png",
+        },
+      ],
+    },
+    {
+      Attachments: [
+        {
+          url: "https://prn.org/doc1.pdf",
+          fileName: "doc1.pdf",
+          isDoc: true,
+          outputPath: "attachment_images/MyCity_AZ_3_1.pdf",
+        },
+        {
+          url: "https://prn.org/img2.jpg",
+          fileName: "img2.jpg",
+          isDoc: false,
+          outputPath: "attachment_images/MyCity_AZ_3_2.jpg",
+        },
+      ],
+    },
+  ]);
 });


### PR DESCRIPTION
We use Handlebars for the template now. A major benefit is that all the logic is moved into the JavaScript file. It separates presentation from content.

This should also be substantially faster because we can parallelize all the downloads by using promises and `Promise.all`.

The script didn't make any meaningful changes on a few sample cities, other than minor whitespace changes.