### PR TITLE
Try to fix HTML not being deployed in CD

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Archive city_detail/ contents
         run: |
           cd city_detail
-          tar -czf ../city_details.tar.gz **/*
+          tar -czf ../city_details.tar.gz .
       - name: Copy city_detail/ to server
         uses: appleboy/scp-action@master
         with:


### PR DESCRIPTION
The GitHub action succeeded. But only `attachment_images/` got updated, not the top-level HTML.

ChatGPT thinks this could be the `**/*` glob, which is not necessary because tar is recursive by default. While `**/*` works on my mac, it's plausible it behaves differently on Linux in CI.