### PR TITLE
Add geocoding to updateMapData

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "jest": "^29.5.0",
         "luxon": "^3.3.0",
         "node-fetch": "^2.6.11",
+        "node-geocoder": "^4.2.0",
         "papaparse": "^5.4.1",
         "prettier": "^2.8.7"
       }
@@ -2789,6 +2790,12 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -5399,6 +5406,19 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-geocoder": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/node-geocoder/-/node-geocoder-4.2.0.tgz",
+      "integrity": "sha512-ZvUiOHWHLVGlrYPvazXj+VQ9oK+EOMinh/5vWoBwOQiV0eCU7GPtEWrMRNnKvmBVOzZHb1eFe9uoKMFeyygMVA==",
+      "dev": true,
+      "dependencies": {
+        "bluebird": "^3.5.2",
+        "node-fetch": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/node-int64": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "jest": "^29.5.0",
     "luxon": "^3.3.0",
     "node-fetch": "^2.6.11",
+    "node-geocoder": "^4.2.0",
     "papaparse": "^5.4.1",
     "prettier": "^2.8.7"
   },


### PR DESCRIPTION
Tested out by removing some lat long pairs from `tidied_map_data.csv` and seeing that the script correctly finds the same values.

We're using the same Open Streets Map API as we used with R, so we should continue to get the same results. See https://www.npmjs.com/package/node-geocoder.