### PR TITLE
Stop parallelizing downloads in updateCityDetail.js

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -6,3 +6,5 @@ overrides: []
 parserOptions:
   ecmaVersion: latest
   sourceType: module
+rules:
+  no-restricted-syntax: off

--- a/scripts/updateMapData.js
+++ b/scripts/updateMapData.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable no-console */
-/* eslint-disable no-restricted-syntax */
+/* eslint-disable no-await-in-loop */
 
 import fs from "fs/promises";
 
@@ -247,7 +247,6 @@ const ensureRowLatLng = async (row, geocoder) => {
   ];
   for (const getLocationString of locationMethods) {
     const locationString = getLocationString();
-    // eslint-disable-next-line no-await-in-loop
     const geocodeResults = await geocoder.geocode(locationString);
     if (geocodeResults.length > 0) {
       return {
@@ -266,7 +265,6 @@ const addMissingLatLng = async (reportData) => {
   // We use a for loop to avoid making too many network calls -> rate limiting.
   const result = [];
   for (const row of reportData) {
-    // eslint-disable-next-line no-await-in-loop
     result.push(await ensureRowLatLng(row, geocoder));
   }
   return result;


### PR DESCRIPTION
While it makes things much faster to parallelize, I realize it's what was causing rate limiting that resulted in the script failing to run for me.