### PR TITLE
Simplify header

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,29 +6,20 @@
   </head>
   <body>
     <div class="page">
-      <div class="banner">
-        <div class="banner-title">Progress on Parking Mandates</div>
-
-        <div class="banner-icons">
-          <div class="info-icon">
-            <i class="fa-solid fa-circle-info fa-lg" title="About"></i>
-          </div>
-
-          <div class="share-dropdown-icon" title="See sharing options">
-            <i class="fa-solid fa-share-alt fa-lg"></i>
-            <i class="fa-solid fa-caret-down"></i>
-          </div>
-
-          <div class="fullscreen-icon">
-            <a href="https://parkingreform.org/mandates-map" target="_blank">
-              <i
-                class="fa-solid fa-up-right-from-square fa-lg"
-                title="View fullscreen"
-              ></i>
-            </a>
-          </div>
+      <header>
+        <span class="header-title">Parking Mandates Map</span>
+        <div class="header-icons">
+          <i class="fa-solid fa-circle-info fa-lg" title="About"></i>
+          <i class="fa-solid fa-share-alt fa-lg"></i>
+          <a href="https://parkingreform.org/mandates-map" target="_blank">
+            <i
+              class="fa-solid fa-up-right-from-square fa-lg"
+              title="View fullscreen"
+            ></i>
+          </a>
         </div>
-      </div>
+      </header>
+
       <div id="map"></div>
     </div>
     <script type="module">

--- a/src/css/_header.scss
+++ b/src/css/_header.scss
@@ -1,0 +1,32 @@
+$gray: #4d4d4d;
+
+header {
+  padding: 0.5rem 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  font-size: 1rem;
+  background: $gray;
+  color: white;
+
+  svg {
+    color: white;
+  }
+
+  @media only screen and (min-width: 48em) {
+    font-size: 1.5rem;
+  }
+}
+
+.header-icons {
+  display: flex;
+  align-items: center;
+
+  cursor: pointer;
+  font-size: 1rem;
+
+  svg {
+    padding: 0 0.5rem;
+  }
+}

--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -1,6 +1,6 @@
-@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap");
+@use "header";
 
-$gray: #4d4d4d;
+@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap");
 
 html,
 body,
@@ -21,37 +21,4 @@ div.page {
 body,
 .leaflet-container {
   font-family: Poppins, Helvetica, Arial, sans-serif;
-}
-
-/* styling the banner */
-div.banner {
-  display: flex;
-  height: 3rem;
-  align-items: center;
-  padding: 0 0.5rem; /* if too high, will create wrapping*/
-  background: $gray;
-  color: white;
-  justify-content: space-between;
-}
-div.banner-title {
-  font-weight: bold;
-  font-size: 1.25rem;
-  background-color: $gray;
-  color: white;
-}
-
-div.banner-icons {
-  display: flex;
-  align-items: center;
-  cursor: pointer;
-}
-
-.info-icon,
-.share-dropdown-icon,
-.fullscreen-icon {
-  padding: 0.1rem 0.5rem;
-}
-
-div.banner-icons svg {
-  color: white;
 }


### PR DESCRIPTION
Applies some refactors inspired by recent work with the parking lot map:

* dedicated Sass file for the header
* renames classes to say `header` rather than `banner`
* uses a `<header>` element rather than `<div>` for the header to follow semantic web
* removes unused classes for each icon. We can add these back later when needed. Either way, we didn't need divs.
* removes the icon for the drop-down caret. In R, we're achieving it by using the `::after` hack to add an arrow. We should probably do something similar. I'll add back the drop-down later after investigating the best approach. For now, keep it simple